### PR TITLE
Add simple week planner

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="de">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document</title>
-    <link rel="stylesheet" href="style">
+    <title>Wochenplaner</title>
+    <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    
-
+    <h1>Wochenplaner</h1>
+    <div id="planner"></div>
     <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,102 @@
+const days = [
+  'Montag',
+  'Dienstag',
+  'Mittwoch',
+  'Donnerstag',
+  'Freitag',
+  'Samstag',
+  'Sonntag'
+];
+
+const storageKey = 'weekTasks';
+let tasks = {};
+
+function loadTasks() {
+  const data = localStorage.getItem(storageKey);
+  if (data) {
+    try {
+      tasks = JSON.parse(data);
+    } catch (e) {
+      tasks = {};
+    }
+  }
+}
+
+function saveTasks() {
+  localStorage.setItem(storageKey, JSON.stringify(tasks));
+}
+
+function addTask(day, text) {
+  if (!tasks[day]) {
+    tasks[day] = [];
+  }
+  tasks[day].push(text);
+  saveTasks();
+}
+
+function removeTask(day, index) {
+  if (tasks[day]) {
+    tasks[day].splice(index, 1);
+    saveTasks();
+  }
+}
+
+function renderPlanner() {
+  const planner = document.getElementById('planner');
+  planner.innerHTML = '';
+
+  days.forEach(day => {
+    const container = document.createElement('div');
+    container.className = 'day';
+
+    const header = document.createElement('h2');
+    header.textContent = day;
+    container.appendChild(header);
+
+    const list = document.createElement('ul');
+    (tasks[day] || []).forEach((taskText, idx) => {
+      const li = document.createElement('li');
+      const span = document.createElement('span');
+      span.textContent = taskText;
+
+      const btn = document.createElement('button');
+      btn.textContent = '✕';
+      btn.addEventListener('click', () => {
+        removeTask(day, idx);
+        renderPlanner();
+      });
+
+      li.appendChild(span);
+      li.appendChild(btn);
+      list.appendChild(li);
+    });
+    container.appendChild(list);
+
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.placeholder = 'Neue Aufgabe';
+    container.appendChild(input);
+
+    const addBtn = document.createElement('button');
+    addBtn.textContent = 'Hinzufügen';
+    addBtn.addEventListener('click', () => {
+      if (input.value.trim() !== '') {
+        addTask(day, input.value.trim());
+        input.value = '';
+        renderPlanner();
+      }
+    });
+    container.appendChild(addBtn);
+
+    input.addEventListener('keypress', e => {
+      if (e.key === 'Enter') {
+        addBtn.click();
+      }
+    });
+
+    planner.appendChild(container);
+  });
+}
+
+loadTasks();
+renderPlanner();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,41 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 20px;
+}
+
+#planner {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 20px;
+}
+
+.day {
+    border: 1px solid #ccc;
+    padding: 10px;
+    border-radius: 4px;
+}
+
+.day h2 {
+    margin-top: 0;
+}
+
+.day ul {
+    list-style: none;
+    padding-left: 0;
+}
+
+.day li {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 5px;
+}
+
+.day button {
+    margin-left: 5px;
+}
+
+input[type="text"] {
+    width: calc(100% - 10px);
+    margin-bottom: 5px;
+}


### PR DESCRIPTION
## Summary
- build minimal HTML layout for the week planner
- implement weekly planner logic in `script.js`
- style the page with a small grid layout

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68574a1caf2883268e5e79f77afbafbd