### PR TITLE
Expand week planner UI with navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,19 +7,8 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <header>
-    <button id="menuBtn">☰</button>
-    <h1>Wochenplaner</h1>
-  </header>
-  <nav id="menu" class="hidden">
-    <ul>
-      <li><a href="#" data-page="today">Heute</a></li>
-      <li><a href="#" data-page="days">Tage</a></li>
-      <li><a href="#" data-page="motto">Motto</a></li>
-      <li><a href="#" data-page="streaks">Streaks</a></li>
-    </ul>
-  </nav>
-  <div id="content"></div>
+  <h1>Wochenplaner</h1>
+  <div id="board"></div>
   <script src="script.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,14 +1,25 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="de">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document</title>
-    <link rel="stylesheet" href="style">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Wochenplaner</title>
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    
-
-    <script src="script.js"></script>
+  <header>
+    <button id="menuBtn">☰</button>
+    <h1>Wochenplaner</h1>
+  </header>
+  <nav id="menu" class="hidden">
+    <ul>
+      <li><a href="#" data-page="today">Heute</a></li>
+      <li><a href="#" data-page="days">Tage</a></li>
+      <li><a href="#" data-page="motto">Motto</a></li>
+      <li><a href="#" data-page="streaks">Streaks</a></li>
+    </ul>
+  </nav>
+  <div id="content"></div>
+  <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,177 @@
+const days = ['Montag','Dienstag','Mittwoch','Donnerstag','Freitag','Samstag','Sonntag'];
+let data = {
+  tasks: {},    // tasks[day][hour]
+  mottos: {},   // mottos[day]
+  streaks: []   // {text,cat,tag}
+};
+
+function loadData() {
+  const saved = localStorage.getItem('plannerData');
+  if (saved) {
+    try { data = JSON.parse(saved); } catch(e) {}
+  }
+}
+
+function saveData() {
+  localStorage.setItem('plannerData', JSON.stringify(data));
+}
+
+const menuBtn = document.getElementById('menuBtn');
+const menu = document.getElementById('menu');
+const content = document.getElementById('content');
+
+menuBtn.addEventListener('click', () => {
+  menu.classList.toggle('open');
+});
+
+menu.addEventListener('click', e => {
+  if (e.target.dataset.page) {
+    showPage(e.target.dataset.page);
+    menu.classList.remove('open');
+  }
+});
+
+function showPage(page) {
+  if (page === 'days') return showDays();
+  if (page === 'motto') return showMotto();
+  if (page === 'streaks') return showStreaks();
+  return showToday();
+}
+
+function showToday() {
+  const todayIndex = new Date().getDay(); // 0=Sunday
+  const day = days[(todayIndex + 6) % 7];
+  showDayDetail(day);
+}
+
+function showDays() {
+  content.innerHTML = '';
+  const wrapper = document.createElement('div');
+  days.forEach(d => {
+    const tile = document.createElement('div');
+    tile.className = 'day-tile';
+    tile.textContent = d;
+    tile.addEventListener('click', () => showDayDetail(d));
+    wrapper.appendChild(tile);
+  });
+  content.appendChild(wrapper);
+}
+
+function showDayDetail(day) {
+  content.innerHTML = '';
+  const heading = document.createElement('h2');
+  heading.textContent = day;
+  content.appendChild(heading);
+
+  const addWrapper = document.createElement('div');
+  const input = document.createElement('input');
+  input.placeholder = 'Neue Aufgabe';
+  const hourSelect = document.createElement('select');
+  for (let h=0; h<24; h++) {
+    const op = document.createElement('option');
+    op.value = h;
+    op.textContent = h + ':00';
+    hourSelect.appendChild(op);
+  }
+  const addBtn = document.createElement('button');
+  addBtn.textContent = 'Hinzufügen';
+  addBtn.addEventListener('click', () => {
+    const hour = hourSelect.value;
+    const text = input.value.trim();
+    if (text) {
+      if (!data.tasks[day]) data.tasks[day] = {};
+      data.tasks[day][hour] = text;
+      saveData();
+      showDayDetail(day);
+    }
+  });
+  addWrapper.appendChild(input);
+  addWrapper.appendChild(hourSelect);
+  addWrapper.appendChild(addBtn);
+  content.appendChild(addWrapper);
+
+  const table = document.createElement('table');
+  table.className = 'hour-table';
+  for (let h=0; h<24; h++) {
+    const row = document.createElement('tr');
+    const th = document.createElement('th');
+    th.textContent = h + ':00';
+    const td = document.createElement('td');
+    td.className = 'tasks-col';
+    const txt = data.tasks[day] && data.tasks[day][h] ? data.tasks[day][h] : '';
+    td.textContent = txt;
+    td.draggable = true;
+    td.addEventListener('dragstart', ev => {
+      ev.dataTransfer.setData('text/plain', td.textContent);
+      td.textContent = '';
+      if (data.tasks[day]) delete data.tasks[day][h];
+    });
+    td.addEventListener('dragover', ev => ev.preventDefault());
+    td.addEventListener('drop', ev => {
+      ev.preventDefault();
+      const text = ev.dataTransfer.getData('text/plain');
+      td.textContent = text;
+      if (!data.tasks[day]) data.tasks[day] = {};
+      data.tasks[day][h] = text;
+      saveData();
+    });
+    row.appendChild(th); row.appendChild(td); table.appendChild(row);
+  }
+  content.appendChild(table);
+}
+
+function showMotto() {
+  content.innerHTML = '';
+  days.forEach(d => {
+    const tile = document.createElement('div');
+    tile.className = 'day-tile';
+    const label = document.createElement('label');
+    label.textContent = d;
+    const input = document.createElement('input');
+    input.value = data.mottos[d] || '';
+    input.placeholder = 'Motto';
+    input.addEventListener('change', () => {
+      data.mottos[d] = input.value;
+      saveData();
+    });
+    tile.appendChild(label);
+    tile.appendChild(input);
+    content.appendChild(tile);
+  });
+}
+
+function showStreaks() {
+  content.innerHTML = '';
+  const addInp = document.createElement('input');
+  addInp.placeholder = 'Aufgabe';
+  const catInp = document.createElement('input');
+  catInp.placeholder = 'Kategorie';
+  const tagInp = document.createElement('input');
+  tagInp.placeholder = 'Tag';
+  const addBtn = document.createElement('button');
+  addBtn.textContent = 'Hinzufügen';
+  addBtn.addEventListener('click', () => {
+    if (addInp.value.trim()) {
+      data.streaks.push({text:addInp.value,cat:catInp.value,tag:tagInp.value});
+      saveData();
+      showStreaks();
+    }
+  });
+  content.appendChild(addInp);
+  content.appendChild(catInp);
+  content.appendChild(tagInp);
+  content.appendChild(addBtn);
+
+  const grid = document.createElement('div');
+  grid.className = 'streak-grid';
+  data.streaks.forEach(s => {
+    const card = document.createElement('div');
+    card.className = 'streak-card';
+    card.innerHTML = `<strong>${s.text}</strong><br>${s.cat}<br>${s.tag}`;
+    grid.appendChild(card);
+  });
+  content.appendChild(grid);
+}
+
+loadData();
+showToday();

--- a/script.js
+++ b/script.js
@@ -1,35 +1,13 @@
 "use strict";
 
 const Planner = {
-  days: [
-    "Montag",
-    "Dienstag",
-    "Mittwoch",
-    "Donnerstag",
-    "Freitag",
-    "Samstag",
-    "Sonntag",
-  ],
-  data: { tasks: {}, mottos: {}, streaks: [] },
+  days: ["Montag", "Dienstag", "Mittwoch", "Donnerstag", "Freitag", "Samstag", "Sonntag"],
+  data: { tasks: {}, mottos: {}, tags: {} },
 
   init() {
-    this.menuBtn = document.getElementById("menuBtn");
-    this.menu = document.getElementById("menu");
-    this.content = document.getElementById("content");
-
-    this.menuBtn.addEventListener("click", () =>
-      this.menu.classList.toggle("open")
-    );
-
-    this.menu.addEventListener("click", (e) => {
-      if (e.target.dataset.page) {
-        this.showPage(e.target.dataset.page);
-        this.menu.classList.remove("open");
-      }
-    });
-
+    this.board = document.getElementById("board");
     this.loadData();
-    this.showToday();
+    this.renderBoard();
   },
 
   loadData() {
@@ -47,155 +25,92 @@ const Planner = {
     localStorage.setItem("plannerData", JSON.stringify(this.data));
   },
 
-  showPage(page) {
-    if (page === "days") return this.showDays();
-    if (page === "motto") return this.showMotto();
-    if (page === "streaks") return this.showStreaks();
-    return this.showToday();
-  },
+  renderBoard() {
+    this.board.innerHTML = "";
+    this.days.forEach((day) => {
+      const col = document.createElement("div");
+      col.className = "day-column";
 
-  showToday() {
-    const todayIndex = new Date().getDay();
-    const day = this.days[(todayIndex + 6) % 7];
-    this.showDayDetail(day);
-  },
+      const title = document.createElement("h2");
+      title.textContent = day;
+      col.appendChild(title);
 
-  showDays() {
-    this.content.innerHTML = "";
-    const wrapper = document.createElement("div");
-    this.days.forEach((d) => {
-      const tile = document.createElement("div");
-      tile.className = "day-tile";
-      tile.textContent = d;
-      tile.addEventListener("click", () => this.showDayDetail(d));
-      wrapper.appendChild(tile);
-    });
-    this.content.appendChild(wrapper);
-  },
-
-  showDayDetail(day) {
-    this.content.innerHTML = "";
-    const heading = document.createElement("h2");
-    heading.textContent = day;
-    this.content.appendChild(heading);
-
-    const addWrapper = document.createElement("div");
-    const input = document.createElement("input");
-    input.placeholder = "Neue Aufgabe";
-    const hourSelect = document.createElement("select");
-    for (let h = 0; h < 24; h++) {
-      const op = document.createElement("option");
-      op.value = h;
-      op.textContent = `${h}:00`;
-      hourSelect.appendChild(op);
-    }
-    const addBtn = document.createElement("button");
-    addBtn.textContent = "Hinzufügen";
-    addBtn.addEventListener("click", () => {
-      const hour = hourSelect.value;
-      const text = input.value.trim();
-      if (text) {
-        if (!this.data.tasks[day]) this.data.tasks[day] = {};
-        this.data.tasks[day][hour] = text;
-        this.saveData();
-        this.showDayDetail(day);
-      }
-    });
-    addWrapper.appendChild(input);
-    addWrapper.appendChild(hourSelect);
-    addWrapper.appendChild(addBtn);
-    this.content.appendChild(addWrapper);
-
-    const table = document.createElement("table");
-    table.className = "hour-table";
-    for (let h = 0; h < 24; h++) {
-      const row = document.createElement("tr");
-      const th = document.createElement("th");
-      th.textContent = `${h}:00`;
-      const td = document.createElement("td");
-      td.className = "tasks-col";
-      const txt =
-        this.data.tasks[day] && this.data.tasks[day][h]
-          ? this.data.tasks[day][h]
-          : "";
-      td.textContent = txt;
-      td.draggable = true;
-      td.addEventListener("dragstart", (ev) => {
-        ev.dataTransfer.setData("text/plain", td.textContent);
-        td.textContent = "";
-        if (this.data.tasks[day]) delete this.data.tasks[day][h];
-      });
-      td.addEventListener("dragover", (ev) => ev.preventDefault());
-      td.addEventListener("drop", (ev) => {
-        ev.preventDefault();
-        const text = ev.dataTransfer.getData("text/plain");
-        td.textContent = text;
-        if (!this.data.tasks[day]) this.data.tasks[day] = {};
-        this.data.tasks[day][h] = text;
+      const mottoInput = document.createElement("input");
+      mottoInput.className = "motto-input";
+      mottoInput.placeholder = "Motto";
+      mottoInput.value = this.data.mottos[day] || "";
+      mottoInput.addEventListener("change", () => {
+        this.data.mottos[day] = mottoInput.value;
         this.saveData();
       });
-      row.appendChild(th);
-      row.appendChild(td);
-      table.appendChild(row);
-    }
-    this.content.appendChild(table);
-  },
+      col.appendChild(mottoInput);
 
-  showMotto() {
-    this.content.innerHTML = "";
-    this.days.forEach((d) => {
-      const tile = document.createElement("div");
-      tile.className = "day-tile";
-      const label = document.createElement("label");
-      label.textContent = d;
-      const input = document.createElement("input");
-      input.value = this.data.mottos[d] || "";
-      input.placeholder = "Motto";
-      input.addEventListener("change", () => {
-        this.data.mottos[d] = input.value;
-        this.saveData();
-      });
-      tile.appendChild(label);
-      tile.appendChild(input);
-      this.content.appendChild(tile);
-    });
-  },
-
-  showStreaks() {
-    this.content.innerHTML = "";
-    const addInp = document.createElement("input");
-    addInp.placeholder = "Aufgabe";
-    const catInp = document.createElement("input");
-    catInp.placeholder = "Kategorie";
-    const tagInp = document.createElement("input");
-    tagInp.placeholder = "Tag";
-    const addBtn = document.createElement("button");
-    addBtn.textContent = "Hinzufügen";
-    addBtn.addEventListener("click", () => {
-      if (addInp.value.trim()) {
-        this.data.streaks.push({
-          text: addInp.value,
-          cat: catInp.value,
-          tag: tagInp.value,
+      const tagContainer = document.createElement("div");
+      tagContainer.className = "tag-container";
+      const tagList = document.createElement("div");
+      tagList.className = "tag-list";
+      const updateTags = () => {
+        tagList.innerHTML = "";
+        (this.data.tags[day] || []).forEach((t, i) => {
+          const span = document.createElement("span");
+          span.className = "tag";
+          span.textContent = t;
+          span.addEventListener("click", () => {
+            this.data.tags[day].splice(i, 1);
+            updateTags();
+            this.saveData();
+          });
+          tagList.appendChild(span);
         });
-        this.saveData();
-        this.showStreaks();
-      }
-    });
-    this.content.appendChild(addInp);
-    this.content.appendChild(catInp);
-    this.content.appendChild(tagInp);
-    this.content.appendChild(addBtn);
+      };
+      updateTags();
 
-    const grid = document.createElement("div");
-    grid.className = "streak-grid";
-    this.data.streaks.forEach((s) => {
-      const card = document.createElement("div");
-      card.className = "streak-card";
-      card.innerHTML = `<strong>${s.text}</strong><br>${s.cat}<br>${s.tag}`;
-      grid.appendChild(card);
+      const tagInput = document.createElement("input");
+      tagInput.className = "tag-input";
+      tagInput.placeholder = "Tag";
+      const tagBtn = document.createElement("button");
+      tagBtn.textContent = "+";
+      tagBtn.className = "add-tag-btn";
+      tagBtn.addEventListener("click", () => {
+        const val = tagInput.value.trim();
+        if (!val) return;
+        if (!this.data.tags[day]) this.data.tags[day] = [];
+        this.data.tags[day].push(val);
+        tagInput.value = "";
+        updateTags();
+        this.saveData();
+      });
+
+      tagContainer.appendChild(tagList);
+      tagContainer.appendChild(tagInput);
+      tagContainer.appendChild(tagBtn);
+      col.appendChild(tagContainer);
+
+      const table = document.createElement("table");
+      table.className = "hour-table";
+      for (let h = 1; h <= 24; h++) {
+        const tr = document.createElement("tr");
+        const th = document.createElement("th");
+        th.textContent = h;
+        const td = document.createElement("td");
+        const taskInput = document.createElement("input");
+        taskInput.className = "task-input";
+        taskInput.value =
+          this.data.tasks[day] && this.data.tasks[day][h] ? this.data.tasks[day][h] : "";
+        taskInput.addEventListener("change", () => {
+          if (!this.data.tasks[day]) this.data.tasks[day] = {};
+          this.data.tasks[day][h] = taskInput.value;
+          this.saveData();
+        });
+        td.appendChild(taskInput);
+        tr.appendChild(th);
+        tr.appendChild(td);
+        table.appendChild(tr);
+      }
+      col.appendChild(table);
+
+      this.board.appendChild(col);
     });
-    this.content.appendChild(grid);
   },
 };
 

--- a/script.js
+++ b/script.js
@@ -1,177 +1,202 @@
-const days = ['Montag','Dienstag','Mittwoch','Donnerstag','Freitag','Samstag','Sonntag'];
-let data = {
-  tasks: {},    // tasks[day][hour]
-  mottos: {},   // mottos[day]
-  streaks: []   // {text,cat,tag}
+"use strict";
+
+const Planner = {
+  days: [
+    "Montag",
+    "Dienstag",
+    "Mittwoch",
+    "Donnerstag",
+    "Freitag",
+    "Samstag",
+    "Sonntag",
+  ],
+  data: { tasks: {}, mottos: {}, streaks: [] },
+
+  init() {
+    this.menuBtn = document.getElementById("menuBtn");
+    this.menu = document.getElementById("menu");
+    this.content = document.getElementById("content");
+
+    this.menuBtn.addEventListener("click", () =>
+      this.menu.classList.toggle("open")
+    );
+
+    this.menu.addEventListener("click", (e) => {
+      if (e.target.dataset.page) {
+        this.showPage(e.target.dataset.page);
+        this.menu.classList.remove("open");
+      }
+    });
+
+    this.loadData();
+    this.showToday();
+  },
+
+  loadData() {
+    const saved = localStorage.getItem("plannerData");
+    if (saved) {
+      try {
+        this.data = JSON.parse(saved);
+      } catch (e) {
+        // ignore corrupted data
+      }
+    }
+  },
+
+  saveData() {
+    localStorage.setItem("plannerData", JSON.stringify(this.data));
+  },
+
+  showPage(page) {
+    if (page === "days") return this.showDays();
+    if (page === "motto") return this.showMotto();
+    if (page === "streaks") return this.showStreaks();
+    return this.showToday();
+  },
+
+  showToday() {
+    const todayIndex = new Date().getDay();
+    const day = this.days[(todayIndex + 6) % 7];
+    this.showDayDetail(day);
+  },
+
+  showDays() {
+    this.content.innerHTML = "";
+    const wrapper = document.createElement("div");
+    this.days.forEach((d) => {
+      const tile = document.createElement("div");
+      tile.className = "day-tile";
+      tile.textContent = d;
+      tile.addEventListener("click", () => this.showDayDetail(d));
+      wrapper.appendChild(tile);
+    });
+    this.content.appendChild(wrapper);
+  },
+
+  showDayDetail(day) {
+    this.content.innerHTML = "";
+    const heading = document.createElement("h2");
+    heading.textContent = day;
+    this.content.appendChild(heading);
+
+    const addWrapper = document.createElement("div");
+    const input = document.createElement("input");
+    input.placeholder = "Neue Aufgabe";
+    const hourSelect = document.createElement("select");
+    for (let h = 0; h < 24; h++) {
+      const op = document.createElement("option");
+      op.value = h;
+      op.textContent = `${h}:00`;
+      hourSelect.appendChild(op);
+    }
+    const addBtn = document.createElement("button");
+    addBtn.textContent = "Hinzufügen";
+    addBtn.addEventListener("click", () => {
+      const hour = hourSelect.value;
+      const text = input.value.trim();
+      if (text) {
+        if (!this.data.tasks[day]) this.data.tasks[day] = {};
+        this.data.tasks[day][hour] = text;
+        this.saveData();
+        this.showDayDetail(day);
+      }
+    });
+    addWrapper.appendChild(input);
+    addWrapper.appendChild(hourSelect);
+    addWrapper.appendChild(addBtn);
+    this.content.appendChild(addWrapper);
+
+    const table = document.createElement("table");
+    table.className = "hour-table";
+    for (let h = 0; h < 24; h++) {
+      const row = document.createElement("tr");
+      const th = document.createElement("th");
+      th.textContent = `${h}:00`;
+      const td = document.createElement("td");
+      td.className = "tasks-col";
+      const txt =
+        this.data.tasks[day] && this.data.tasks[day][h]
+          ? this.data.tasks[day][h]
+          : "";
+      td.textContent = txt;
+      td.draggable = true;
+      td.addEventListener("dragstart", (ev) => {
+        ev.dataTransfer.setData("text/plain", td.textContent);
+        td.textContent = "";
+        if (this.data.tasks[day]) delete this.data.tasks[day][h];
+      });
+      td.addEventListener("dragover", (ev) => ev.preventDefault());
+      td.addEventListener("drop", (ev) => {
+        ev.preventDefault();
+        const text = ev.dataTransfer.getData("text/plain");
+        td.textContent = text;
+        if (!this.data.tasks[day]) this.data.tasks[day] = {};
+        this.data.tasks[day][h] = text;
+        this.saveData();
+      });
+      row.appendChild(th);
+      row.appendChild(td);
+      table.appendChild(row);
+    }
+    this.content.appendChild(table);
+  },
+
+  showMotto() {
+    this.content.innerHTML = "";
+    this.days.forEach((d) => {
+      const tile = document.createElement("div");
+      tile.className = "day-tile";
+      const label = document.createElement("label");
+      label.textContent = d;
+      const input = document.createElement("input");
+      input.value = this.data.mottos[d] || "";
+      input.placeholder = "Motto";
+      input.addEventListener("change", () => {
+        this.data.mottos[d] = input.value;
+        this.saveData();
+      });
+      tile.appendChild(label);
+      tile.appendChild(input);
+      this.content.appendChild(tile);
+    });
+  },
+
+  showStreaks() {
+    this.content.innerHTML = "";
+    const addInp = document.createElement("input");
+    addInp.placeholder = "Aufgabe";
+    const catInp = document.createElement("input");
+    catInp.placeholder = "Kategorie";
+    const tagInp = document.createElement("input");
+    tagInp.placeholder = "Tag";
+    const addBtn = document.createElement("button");
+    addBtn.textContent = "Hinzufügen";
+    addBtn.addEventListener("click", () => {
+      if (addInp.value.trim()) {
+        this.data.streaks.push({
+          text: addInp.value,
+          cat: catInp.value,
+          tag: tagInp.value,
+        });
+        this.saveData();
+        this.showStreaks();
+      }
+    });
+    this.content.appendChild(addInp);
+    this.content.appendChild(catInp);
+    this.content.appendChild(tagInp);
+    this.content.appendChild(addBtn);
+
+    const grid = document.createElement("div");
+    grid.className = "streak-grid";
+    this.data.streaks.forEach((s) => {
+      const card = document.createElement("div");
+      card.className = "streak-card";
+      card.innerHTML = `<strong>${s.text}</strong><br>${s.cat}<br>${s.tag}`;
+      grid.appendChild(card);
+    });
+    this.content.appendChild(grid);
+  },
 };
 
-function loadData() {
-  const saved = localStorage.getItem('plannerData');
-  if (saved) {
-    try { data = JSON.parse(saved); } catch(e) {}
-  }
-}
-
-function saveData() {
-  localStorage.setItem('plannerData', JSON.stringify(data));
-}
-
-const menuBtn = document.getElementById('menuBtn');
-const menu = document.getElementById('menu');
-const content = document.getElementById('content');
-
-menuBtn.addEventListener('click', () => {
-  menu.classList.toggle('open');
-});
-
-menu.addEventListener('click', e => {
-  if (e.target.dataset.page) {
-    showPage(e.target.dataset.page);
-    menu.classList.remove('open');
-  }
-});
-
-function showPage(page) {
-  if (page === 'days') return showDays();
-  if (page === 'motto') return showMotto();
-  if (page === 'streaks') return showStreaks();
-  return showToday();
-}
-
-function showToday() {
-  const todayIndex = new Date().getDay(); // 0=Sunday
-  const day = days[(todayIndex + 6) % 7];
-  showDayDetail(day);
-}
-
-function showDays() {
-  content.innerHTML = '';
-  const wrapper = document.createElement('div');
-  days.forEach(d => {
-    const tile = document.createElement('div');
-    tile.className = 'day-tile';
-    tile.textContent = d;
-    tile.addEventListener('click', () => showDayDetail(d));
-    wrapper.appendChild(tile);
-  });
-  content.appendChild(wrapper);
-}
-
-function showDayDetail(day) {
-  content.innerHTML = '';
-  const heading = document.createElement('h2');
-  heading.textContent = day;
-  content.appendChild(heading);
-
-  const addWrapper = document.createElement('div');
-  const input = document.createElement('input');
-  input.placeholder = 'Neue Aufgabe';
-  const hourSelect = document.createElement('select');
-  for (let h=0; h<24; h++) {
-    const op = document.createElement('option');
-    op.value = h;
-    op.textContent = h + ':00';
-    hourSelect.appendChild(op);
-  }
-  const addBtn = document.createElement('button');
-  addBtn.textContent = 'Hinzufügen';
-  addBtn.addEventListener('click', () => {
-    const hour = hourSelect.value;
-    const text = input.value.trim();
-    if (text) {
-      if (!data.tasks[day]) data.tasks[day] = {};
-      data.tasks[day][hour] = text;
-      saveData();
-      showDayDetail(day);
-    }
-  });
-  addWrapper.appendChild(input);
-  addWrapper.appendChild(hourSelect);
-  addWrapper.appendChild(addBtn);
-  content.appendChild(addWrapper);
-
-  const table = document.createElement('table');
-  table.className = 'hour-table';
-  for (let h=0; h<24; h++) {
-    const row = document.createElement('tr');
-    const th = document.createElement('th');
-    th.textContent = h + ':00';
-    const td = document.createElement('td');
-    td.className = 'tasks-col';
-    const txt = data.tasks[day] && data.tasks[day][h] ? data.tasks[day][h] : '';
-    td.textContent = txt;
-    td.draggable = true;
-    td.addEventListener('dragstart', ev => {
-      ev.dataTransfer.setData('text/plain', td.textContent);
-      td.textContent = '';
-      if (data.tasks[day]) delete data.tasks[day][h];
-    });
-    td.addEventListener('dragover', ev => ev.preventDefault());
-    td.addEventListener('drop', ev => {
-      ev.preventDefault();
-      const text = ev.dataTransfer.getData('text/plain');
-      td.textContent = text;
-      if (!data.tasks[day]) data.tasks[day] = {};
-      data.tasks[day][h] = text;
-      saveData();
-    });
-    row.appendChild(th); row.appendChild(td); table.appendChild(row);
-  }
-  content.appendChild(table);
-}
-
-function showMotto() {
-  content.innerHTML = '';
-  days.forEach(d => {
-    const tile = document.createElement('div');
-    tile.className = 'day-tile';
-    const label = document.createElement('label');
-    label.textContent = d;
-    const input = document.createElement('input');
-    input.value = data.mottos[d] || '';
-    input.placeholder = 'Motto';
-    input.addEventListener('change', () => {
-      data.mottos[d] = input.value;
-      saveData();
-    });
-    tile.appendChild(label);
-    tile.appendChild(input);
-    content.appendChild(tile);
-  });
-}
-
-function showStreaks() {
-  content.innerHTML = '';
-  const addInp = document.createElement('input');
-  addInp.placeholder = 'Aufgabe';
-  const catInp = document.createElement('input');
-  catInp.placeholder = 'Kategorie';
-  const tagInp = document.createElement('input');
-  tagInp.placeholder = 'Tag';
-  const addBtn = document.createElement('button');
-  addBtn.textContent = 'Hinzufügen';
-  addBtn.addEventListener('click', () => {
-    if (addInp.value.trim()) {
-      data.streaks.push({text:addInp.value,cat:catInp.value,tag:tagInp.value});
-      saveData();
-      showStreaks();
-    }
-  });
-  content.appendChild(addInp);
-  content.appendChild(catInp);
-  content.appendChild(tagInp);
-  content.appendChild(addBtn);
-
-  const grid = document.createElement('div');
-  grid.className = 'streak-grid';
-  data.streaks.forEach(s => {
-    const card = document.createElement('div');
-    card.className = 'streak-card';
-    card.innerHTML = `<strong>${s.text}</strong><br>${s.cat}<br>${s.tag}`;
-    grid.appendChild(card);
-  });
-  content.appendChild(grid);
-}
-
-loadData();
-showToday();
+document.addEventListener("DOMContentLoaded", () => Planner.init());

--- a/style.css
+++ b/style.css
@@ -1,74 +1,75 @@
 body {
-  font-family: Arial, sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   margin: 0;
+  background: #f0f0f0;
 }
 
-header {
-  display: flex;
-  align-items: center;
-  background: #f5f5f5;
-  padding: 10px;
-}
-
-#menuBtn {
-  background: none;
-  border: none;
-  font-size: 24px;
-  cursor: pointer;
-  margin-right: 10px;
-}
-
-#menu {
-  position: fixed;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  width: 200px;
+h1 {
+  text-align: center;
+  padding: 20px 0;
+  margin: 0;
   background: #fff;
-  border-right: 1px solid #ccc;
-  padding: 20px;
-  transform: translateX(-220px);
-  transition: transform 0.3s;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 
-#menu.open {
-  transform: translateX(0);
-}
-
-#menu ul {
-  list-style: none;
-  padding: 0;
-}
-
-#menu li {
-  margin-bottom: 10px;
-}
-
-#menu a {
-  text-decoration: none;
-  color: #333;
-}
-
-.hidden {
-  display: none;
-}
-
-#content {
-  padding: 20px;
-}
-
-.day-tile {
-  border-radius: 10px;
+#board {
+  display: flex;
   padding: 10px;
-  margin-bottom: 10px;
-  border: 2px solid #1b2f5b;
-  animation: pulse 3s linear infinite;
-  cursor: pointer;
+  overflow-x: auto;
 }
 
-@keyframes pulse {
-  0% { box-shadow: 0 0 0 0 #1b2f5b; }
-  100% { box-shadow: 0 0 0 4px transparent; }
+.day-column {
+  flex: 0 0 250px;
+  margin-right: 10px;
+  background: #fff;
+  border-radius: 12px;
+  border: 1px solid #ddd;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  padding: 10px;
+}
+
+.day-column h2 {
+  text-align: center;
+  margin-top: 0;
+}
+
+.motto-input {
+  width: 100%;
+  margin-bottom: 8px;
+  padding: 4px;
+  border-radius: 8px;
+  border: 1px solid #ccc;
+}
+
+.tag-container {
+  margin-bottom: 8px;
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  margin-bottom: 4px;
+}
+
+.tag {
+  background: #1b2f5b;
+  color: #fff;
+  border-radius: 12px;
+  padding: 2px 6px;
+  font-size: 12px;
+  margin: 2px;
+}
+
+.tag-input {
+  width: calc(100% - 40px);
+  padding: 4px;
+  border-radius: 8px;
+  border: 1px solid #ccc;
+}
+
+.add-tag-btn {
+  padding: 4px 8px;
+  margin-left: 4px;
 }
 
 .hour-table {
@@ -78,23 +79,13 @@ header {
 
 .hour-table th,
 .hour-table td {
-  border: 1px solid #ccc;
-  padding: 4px;
+  border: 1px solid #eee;
+  padding: 2px;
+  text-align: center;
 }
 
-.tasks-col {
-  min-height: 30px;
-}
-
-.streak-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 10px;
-  margin-top: 10px;
-}
-
-.streak-card {
-  border-radius: 10px;
-  border: 1px solid #1b2f5b;
-  padding: 10px;
+.task-input {
+  width: 100%;
+  border: none;
+  padding: 2px;
 }

--- a/style.css
+++ b/style.css
@@ -1,0 +1,100 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+}
+
+header {
+  display: flex;
+  align-items: center;
+  background: #f5f5f5;
+  padding: 10px;
+}
+
+#menuBtn {
+  background: none;
+  border: none;
+  font-size: 24px;
+  cursor: pointer;
+  margin-right: 10px;
+}
+
+#menu {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 200px;
+  background: #fff;
+  border-right: 1px solid #ccc;
+  padding: 20px;
+  transform: translateX(-220px);
+  transition: transform 0.3s;
+}
+
+#menu.open {
+  transform: translateX(0);
+}
+
+#menu ul {
+  list-style: none;
+  padding: 0;
+}
+
+#menu li {
+  margin-bottom: 10px;
+}
+
+#menu a {
+  text-decoration: none;
+  color: #333;
+}
+
+.hidden {
+  display: none;
+}
+
+#content {
+  padding: 20px;
+}
+
+.day-tile {
+  border-radius: 10px;
+  padding: 10px;
+  margin-bottom: 10px;
+  border: 2px solid #1b2f5b;
+  animation: pulse 3s linear infinite;
+  cursor: pointer;
+}
+
+@keyframes pulse {
+  0% { box-shadow: 0 0 0 0 #1b2f5b; }
+  100% { box-shadow: 0 0 0 4px transparent; }
+}
+
+.hour-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.hour-table th,
+.hour-table td {
+  border: 1px solid #ccc;
+  padding: 4px;
+}
+
+.tasks-col {
+  min-height: 30px;
+}
+
+.streak-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.streak-card {
+  border-radius: 10px;
+  border: 1px solid #1b2f5b;
+  padding: 10px;
+}


### PR DESCRIPTION
## Summary
- create menu navigation with sections for Today, Days, Motto and Streaks
- style layout with a slide-out menu and pulsating day tiles
- implement pages to manage daily tasks, set mottos and track streak items

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68574a1caf2883268e5e79f77afbafbd