### PR TITLE
Add kanban style weekly planner

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,41 +1,90 @@
+:root {
+    --bg-color: #f5f5f7;
+    --surface-color: #ffffff;
+    --border-color: #e0e0e0;
+    --radius: 12px;
+    --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
 body {
-    font-family: Arial, sans-serif;
+    font-family: var(--font);
+    background: var(--bg-color);
+    color: #333;
     margin: 0;
     padding: 20px;
 }
 
+h1 {
+    text-align: center;
+    margin-top: 0;
+    margin-bottom: 20px;
+}
+
 #planner {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
     gap: 20px;
+    align-items: flex-start;
 }
 
 .day {
-    border: 1px solid #ccc;
+    background: var(--surface-color);
+    border: 1px solid var(--border-color);
     padding: 10px;
-    border-radius: 4px;
+    border-radius: var(--radius);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    display: flex;
+    flex-direction: column;
 }
 
 .day h2 {
     margin-top: 0;
+    text-align: center;
 }
 
-.day ul {
-    list-style: none;
-    padding-left: 0;
+.motto-input,
+.tag-input,
+.hour input {
+    width: 100%;
+    padding: 6px;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius);
+    box-sizing: border-box;
+    font-family: var(--font);
 }
 
-.day li {
+.tags {
     display: flex;
-    justify-content: space-between;
-    margin-bottom: 5px;
+    flex-wrap: wrap;
+    gap: 4px;
+    margin-bottom: 8px;
 }
 
-.day button {
-    margin-left: 5px;
+.tag {
+    background: #e5e5ea;
+    border-radius: var(--radius);
+    padding: 2px 8px;
+    display: flex;
+    align-items: center;
 }
 
-input[type="text"] {
-    width: calc(100% - 10px);
-    margin-bottom: 5px;
+.tag button {
+    background: none;
+    border: none;
+    cursor: pointer;
+    margin-left: 4px;
 }
+
+.hour {
+    display: flex;
+    align-items: center;
+    margin-bottom: 6px;
+}
+
+.hour label {
+    width: 24px;
+    font-size: 12px;
+    color: #666;
+    margin-right: 4px;
+}
+


### PR DESCRIPTION
## Summary
- modernize layout with Apple-inspired styles
- store a motto, tags and hourly tasks for each day in localStorage
- display seven day columns with 24 hourly task slots each

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685756267e9c83269f35ef11fe920cef